### PR TITLE
Issue 96

### DIFF
--- a/pyorc/api/velocimetry.py
+++ b/pyorc/api/velocimetry.py
@@ -290,7 +290,7 @@ class Velocimetry(ORCBase):
         self._obj[v_y] = self._obj[v_y].where(self._obj[corr] > tolerance)
         # return ds
 
-    def filter_temporal_count(self, tolerance=0.5):
+    def filter_temporal_count(self, tolerance=0.33):
         """Masks values with a too low correlation.
 
         Parameters

--- a/pyorc/api/velocimetry.py
+++ b/pyorc/api/velocimetry.py
@@ -33,6 +33,7 @@ class Velocimetry(ORCBase):
             filter_velocity=True,
             filter_corr=True,
             filter_neighbour=True,
+            filter_count=True,
             kwargs_corr={},
             kwargs_std={},
             kwargs_angle={},
@@ -88,11 +89,14 @@ class Velocimetry(ORCBase):
             ds.velocimetry.filter_temporal_velocity(v_x=v_x, v_y=v_y, **kwargs_velocity)
         if filter_neighbour:
             ds.velocimetry.filter_temporal_neighbour(v_x=v_x, v_y=v_y, **kwargs_neighbour)
-        # finalize with temporally dependent filters
+        # continue with temporally dependent filters
         if filter_std:
             ds.velocimetry.filter_temporal_std(v_x=v_x, v_y=v_y, **kwargs_std)
         if filter_angle:
             ds.velocimetry.filter_temporal_angle(v_x=v_x, v_y=v_y, **kwargs_angle)
+        # finalize with absolute count threshold filter
+        if filter_count:
+            ds.velocimetry.filter_temporal_count(tolerance=0.25)
         ds.attrs = self._obj.attrs
         if inplace:
             self._obj.update(ds)
@@ -286,6 +290,24 @@ class Velocimetry(ORCBase):
         self._obj[v_y] = self._obj[v_y].where(self._obj[corr] > tolerance)
         # return ds
 
+    def filter_temporal_count(self, tolerance=0.5):
+        """Masks values with a too low correlation.
+
+        Parameters
+        ----------
+        tolerance : float (0-1)
+            tolerance for fractional amount of valid velocities after all filters. If less than the fraction is
+            available, the entire velocity will be set to missings.
+
+        Returns
+        -------
+        ds_filter : xr.Dataset
+            count filtered velocity vectors as [time, y, x]
+        """
+        # pass
+        self._obj = self._obj.where(self._obj["v_x"].count(dim="time") > tolerance*len(self._obj.time))
+
+
     def filter_spatial(
             self,
             v_x="v_x",
@@ -445,7 +467,12 @@ class Velocimetry(ORCBase):
             ys="ys",
             distance=None,
             wdw=1,
+            wdw_x_min=None,
+            wdw_x_max=None,
+            wdw_y_min=None,
+            wdw_y_max=None,
             rolling=None,
+            tolerance=0.5,
             quantiles=[0.05, 0.25, 0.5, 0.75, 0.95]
     ):
         """Interpolate all variables to supplied x and y coordinates of a cross section. This function assumes that the
@@ -466,7 +493,6 @@ class Velocimetry(ORCBase):
         s : tuple or list-like
             distance from bank coordinates on which interpolation should be done, defaults: None
             if set, these distances will be precisely respected, and not interpolated. ``distance`` will be ignored.
-
         crs : int, dict or str, optional
             coordinate reference system (e.g. EPSG code) in which x, y and z are measured (default: None),
             None assumes crs is the same as crs of xr.Dataset.
@@ -479,8 +505,22 @@ class Velocimetry(ORCBase):
         distance : float, optional
             sampling distance over the cross-section in [m]. the bathymetry points will be interpolated to match this
             distance. If not set, the distance will be estimated from the velocimetry grid resolution. (default: None)
-        wdw : int, window size to use for sampling the velocity. zero means, only cell itself, 1 means 3x3 window.
-            (default: 1)
+        wdw : int, optional
+            window size to use for sampling the velocity. zero means, only cell itself, 1 means 3x3 window.
+            (default: 1) wdw is used to fill wdw_x_min and wdwd_y_min with its negative (-wdw) value, and wdw_y_min and
+            wdw_y_max with its positive value, to create a sampling window.
+        wdw_x_min : int, optional
+            window size in negative x-direction of grid (must be negative), overrules wdw in negative x-direction if set
+        wdw_x_max : int, optional
+            window size in positive x-direction of grid, overrules wdw in positive x-direction if set
+        wdw_y_min : int, optional
+            window size in negative y-direction of grid (must be negative), overrules wdw in negative y-direction if set
+        wdw_y_max : int, optional
+            window size in positive y-direction of grid, overrules wdw in positive x-direction if set.
+        tolerance : float (0-1), optional
+            tolerance on the required amount of sampled data in the window defined by wdw and/or wdw_x_min, wdw_x_max,
+            wdw_y_min and wdw_y_max (if set). At least this fraction of cells each time step must have a data value
+            to return a value. Otherwise the location is given a nan as value.
         rolling : int, optional
             if set other than None (default), a rolling mean over time is applied, before deriving quantile estimates.
         quantiles : list of floats (0-1), optional
@@ -491,6 +531,12 @@ class Velocimetry(ORCBase):
         ds_points: xr.Dataset
             interpolated data at the supplied x and y coordinates over quantiles
         """
+        # set strides
+        wdw_x_min = -wdw if wdw_x_min is None else wdw_x_min
+        wdw_x_max = wdw if wdw_x_max is None else wdw_x_max
+        wdw_y_min = -wdw if wdw_y_min is None else wdw_y_min
+        wdw_y_max = wdw if wdw_y_max is None else wdw_y_max
+
         transform = helpers.affine_from_grid(self._obj[xs].values, self._obj[ys].values)
         if crs is not None:
             # transform coordinates of cross section
@@ -539,10 +585,14 @@ class Velocimetry(ORCBase):
             ds_points = self._obj.interp(x=_x, y=_y)
         else:
             # collect points within a stride, collate and analyze for outliers
-            ds_wdw = xr.concat([self._obj.shift(x=x_stride, y=y_stride) for x_stride in range(-wdw, wdw + 1) for y_stride in
-                                range(-wdw, wdw + 1)], dim="stride")
+            ds_wdw = xr.concat([self._obj.shift(x=x_stride, y=y_stride) for x_stride in range(wdw_x_min, wdw_x_max + 1) for y_stride in
+                                range(wdw_y_min, wdw_y_max + 1)], dim="stride")
             # use the median (not mean) to prevent a large influence of serious outliers
-            ds_effective = ds_wdw.mean(dim="stride", keep_attrs=True)
+            missing_tolerance = ds_wdw.mean(dim="time").count(dim="stride") > tolerance * len(ds_wdw.stride)
+            # missing_tolerance = ds_wdw.count(dim="stride") > tolerance*len(ds_wdw.stride)
+            ds_effective = ds_wdw.median(dim="stride", keep_attrs=True)
+            # remove velocities that are too few in samples
+            ds_effective = ds_effective.where(missing_tolerance)
             ds_points = ds_effective.interp(x=_x, y=_y)
         if np.isnan(ds_points["v_x"].mean(dim="time")).all():
             raise ValueError(

--- a/pyorc/api/velocimetry.py
+++ b/pyorc/api/velocimetry.py
@@ -595,8 +595,9 @@ class Velocimetry(ORCBase):
             ds_effective = ds_effective.where(missing_tolerance)
             ds_points = ds_effective.interp(x=_x, y=_y)
         if np.isnan(ds_points["v_x"].mean(dim="time")).all():
-            raise ValueError(
-                "No valid velocimetry points found over bathymetry. Check if the bathymetry is within the camera objective")
+            warnings.warn(
+                "No valid velocimetry points found over bathymetry. Check if the bathymetry is within the camera objective or anything is visible in objective."
+            )
         # add the xcoords and ycoords (and zcoords if available) originally assigned so that even points outside the grid covered by ds can be
         # found back from this dataset
         ds_points = ds_points.assign_coords(xcoords=("points", list(x)))

--- a/pyorc/api/video.py
+++ b/pyorc/api/video.py
@@ -110,7 +110,19 @@ Camera configuration: {:s}
                 )
         else:
             end_frame = self.frame_count
+        # test if last frame is available, if not search until available frame is found and give warning
+        cap.set(cv2.CAP_PROP_POS_FRAMES, end_frame - 1)
+        ret, img = cap.read()
+        if ret == False:
+            warnings.warn(f"End frame {end_frame} cannot be read from file. Video may be damaged or improperly formatted. Searching for last available frame")
+            while not(ret):
+                end_frame -= 1
+                cap.set(cv2.CAP_PROP_POS_FRAMES, end_frame - 1)
+                ret, img = cap.read()
+            warnings.warn(f"Available end frame found at position {end_frame}")
+
         self.end_frame = end_frame
+
         self.start_frame = start_frame
         if stabilize is not None:
             # select the right recipe dependent on the movie being fixed or moving

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,9 +140,7 @@ def vid():
         end_frame=2,
     )
     yield vid
-    # vid.release()
-    # del vid
-    # return
+
 
 @pytest.fixture
 def vid_cam_config(cam_config):

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -43,7 +43,7 @@ def test_edge_detect(frames_proj):
     frames_edge = frames_proj.frames.edge_detect()
     assert(frames_edge.shape == frames_proj.shape)
     assert(frames_edge[0, 0, 0].values.dtype == "float32"), f'dtype of result is {frames_edge[0, 0, 0].values.dtype}, expected "float32"'
-    assert(np.allclose(frames_edge.values.flatten()[-4:], [3.46875  , 0.328125 , 1.9140625, 4.34375  ]))
+    assert(np.allclose(frames_edge.values.flatten()[-4:], [6.328125, 2.34375, 0.0625, 0.40625]))
 
 
 
@@ -81,9 +81,9 @@ def test_plot_proj(frames_proj, idx):
 @pytest.mark.parametrize(
     "window_size, result",
     [
-        (5, [0.06478927, np.nan, np.nan, 0.08308388]),
-        (10, [0.32011113, 0.22834961, 0.29223198, 0.31207517]),
-        (15, [0.29699332, 0.33740216, 0.33087003, 0.25027668])
+        (5, [0.04290744, np.nan, np.nan, 0.07388695]),
+        (10, [0.25739092, 0.22005227, 0.30368298, 0.33715272]),
+        (15, [0.27460322, 0.3151794, 0.26885322, 0.25401443])
     ]
 )
 def test_get_piv(frames_proj, window_size, result):

--- a/tests/test_transect.py
+++ b/tests/test_transect.py
@@ -7,7 +7,7 @@ def test_get_river_flow(piv_transect):
     piv_transect.transect.get_q()
     piv_transect.transect.get_river_flow()
     # because we only have PIV for one time step, all quantiles will have the same values
-    assert(np.allclose(piv_transect.river_flow.values, [0.08225803, 0.08225803, 0.08225803, 0.08225803, 0.08225803]))
+    assert(np.allclose(piv_transect.river_flow.values, [0.07178371, 0.07555505, 0.08026924, 0.08498342, 0.08875476]))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -51,6 +51,6 @@ def test_get_frame(video, method, result):
 def test_get_frames(video, method):
     # check if the right amount of frames is extracted
     frames = video.get_frames()
-    assert(len(frames) == video.end_frame - video.start_frame)
+    assert(len(frames) == video.end_frame - video.start_frame + 1)
     # check if the time difference is well taken from the fps of the video
     assert(np.allclose(np.diff(frames.time.values), [1./video.fps]))


### PR DESCRIPTION
- Mainly fixes of issues #96 and #98 and adapting tests to accomodate that. The effect for the user is that frames are read from start UNTIL the end frame, instead of UP TO the end frame, and that time stamps of frames are now measured more accurately, and non-equidistant in time. 
- Transects with only NaNs now return only a warning, instead of exiting with a raised error.
- a filter based on a simple count threshold of the relative amount of resolved velocities is added