### PR TITLE
bug with windows machines fixed, where local coordinate system coordinates were in some cases truncated when 64-bit floats were subtracted from 32-bit floats. This is a behaviour in numpy #145

### DIFF
--- a/pyorc/cli/cli_utils.py
+++ b/pyorc/cli/cli_utils.py
@@ -101,7 +101,7 @@ def get_gcps_optimized_fit(src, dst, height, width, c=2., lens_position=None):
     # once optimized, solve the perspective, and estimate the GCP locations with the perspective rot/trans
     coord_mean = np.array(_dst).mean(axis=0)
     _src = np.float32(src)
-    _dst = np.float32(_dst) - coord_mean
+    _dst = np.float32(np.array(_dst) - coord_mean)
     success, rvec, tvec = cv2.solvePnP(_dst, _src, camera_matrix, np.array(dist_coeffs))
 
     # estimate source point location


### PR DESCRIPTION
This bug probably only appeared on windows machines.