### PR TITLE
241 low water levels give multiple polygons in cross section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.8.X] = XXXX-XX-XX
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- issues with plotting cross sections in edge cases with water levels equal to lowest point or above highest point
+
 ## [0.8.7] = 2025-06-30
 ### Added
 - CLI option `--cross_wl`

--- a/pyorc/api/plot.py
+++ b/pyorc/api/plot.py
@@ -184,16 +184,26 @@ def _base_plot(plot_func):
                         planar=False,
                         bottom=False,
                     )
-                    ref._obj.transect.cross_section.plot_water_level(
-                        h=ref._obj.transect.h_a,
-                        length=2.0,
-                        linewidth=3.0,
-                        ax=ax,
-                        camera=True,
-                        swap_y_coords=True,
-                        color="r",
-                        label="water level",
+                    # check if water level is above the lowest level
+                    check_low = (
+                        ref._obj.transect.camera_config.h_to_z(ref._obj.transect.h_a)
+                        > ref._obj.transect.cross_section.z.min()
                     )
+                    check_high = (
+                        ref._obj.transect.camera_config.h_to_z(ref._obj.transect.h_a)
+                        < ref._obj.transect.cross_section.z.max()
+                    )
+                    if check_low and check_high:
+                        ref._obj.transect.cross_section.plot_water_level(
+                            h=ref._obj.transect.h_a,
+                            length=2.0,
+                            linewidth=3.0,
+                            ax=ax,
+                            camera=True,
+                            swap_y_coords=True,
+                            color="r",
+                            label="water level",
+                        )
 
                     # draw some depth lines for better visual interpretation.
                     depth_lines = ref._obj.transect.get_depth_perspective(h=ref._obj.transect.h_a)

--- a/pyorc/plot_helpers.py
+++ b/pyorc/plot_helpers.py
@@ -2,10 +2,11 @@
 
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+from shapely import geometry
 
 
-def plot_3d_polygon(polygon, ax=None, **kwargs):
-    """Plot a shapely.geometry.Polygon on matplotlib 3d ax."""
+def _plot_3d_pol(polygon, ax=None, **kwargs):
+    """Plot single polygon on matplotlib 3d ax."""
     x, y, z = zip(*polygon.exterior.coords)
     verts = [list(zip(x, y, z))]
 
@@ -17,13 +18,27 @@ def plot_3d_polygon(polygon, ax=None, **kwargs):
     return p
 
 
+def plot_3d_polygon(polygon, ax=None, **kwargs):
+    """Plot a shapely.geometry.Polygon or MultiPolygon on matplotlib 3d ax."""
+    if isinstance(polygon, geometry.MultiPolygon):
+        for pol in polygon.geoms:
+            p = _plot_3d_pol(pol, ax=ax, **kwargs)
+    else:
+        p = _plot_3d_pol(polygon, ax=ax, **kwargs)
+    return p
+
+
 def plot_polygon(polygon, ax=None, **kwargs):
-    """Plot a shapely.geometry.Polygon on matplotlib ax."""
-    # x, y = zip(*polygon.exterior.coords)
+    """Plot a shapely.geometry.Polygon or MultiPolygon on matplotlib ax."""
     if ax is None:
         ax = plt.axes()
-    patch = plt.Polygon(polygon.exterior.coords, **kwargs)
-    p = ax.add_patch(patch)
+    if isinstance(polygon, geometry.MultiPolygon):
+        for pol in polygon.geoms:
+            patch = plt.Polygon(pol.exterior.coords, **kwargs)
+            p = ax.add_patch(patch)
+    else:
+        patch = plt.Polygon(polygon.exterior.coords, **kwargs)
+        p = ax.add_patch(patch)
     return p
 
 

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -335,7 +335,7 @@ def test_get_wetted_surface(cs):
     h3 = 94.9
     pol1 = cs.get_wetted_surface(h=h1)
     pol2 = cs.get_wetted_surface(h=h2)
-    assert isinstance(pol1, geometry.Polygon)
+    assert isinstance(pol1, geometry.MultiPolygon)
     assert pol1.has_z
     assert pol2.has_z
 

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -344,8 +344,10 @@ def test_get_wetted_surface(cs):
     assert pol1.has_z
     assert pol2.has_z
 
-    with pytest.raises(ValueError, match="Water level is not crossed"):
-        cs.get_wetted_surface(h=h3)
+    # h3 is above cross section, should still resolve one polygon
+    pol3 = cs.get_wetted_surface(h=h3)
+    assert isinstance(pol3, geometry.MultiPolygon)
+    assert len(pol3.geoms) == 1
 
 
 def test_detect_wl(cs, img):

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -201,12 +201,17 @@ def test_get_cs_waterlevel(cs):
     line = cs.get_cs_waterlevel(h=93.0)
     assert isinstance(line, geometry.LineString)
     assert line.has_z
+    # also try with extend
+    line_extend = cs.get_cs_waterlevel(h=93.0, extend_by=0.2)
+    assert np.isclose(line_extend.length - line.length, 0.2 * 2)
 
 
 def test_get_cs_waterlevel_sz(cs):
     line = cs.get_cs_waterlevel(h=93.0, sz=True)
     assert isinstance(line, geometry.LineString)
     assert line.has_z == False
+    line_extend = cs.get_cs_waterlevel(h=93.0, sz=True, extend_by=0.2)
+    assert np.isclose(line_extend.length - line.length, 0.2 * 2)
 
 
 def test_get_csl_point(cs):


### PR DESCRIPTION
this fixes #241 by relaxing plotting methods and using a `MultiPolygon` approach for cross-sectional areas in cases where there are multiple polygons crossing the bottom (typically with low water levels and side channels).