### PR TITLE
285 replace error on masks with correlation averaging for a warning and skip

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,10 +56,6 @@ jobs:
       - name: Test
         run: python -m pytest --verbose --cov=pyorc --cov-report xml
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v5
-#        env:
-#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,10 @@ env/
 
 # PyCharm
 .idea/
+
+# VS Code
+.vscode/
+
+# examples
+examples/ngwerere/outputs
+examples/*.nc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Deprecated
 ### Removed
 ### Fixed
+- Videos that are ungracefully closed during writing do not have proper metadata and caused read errors. This is fixed
+  for reading videos, but only when read with `lazy=False`. With `lazy=True` a clear error is raised that tells the
+  user that the video is not complete and that a new attempt with `lazy=False` may result in success.
 
 
 ## [0.9.4] = 2026-02-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.9.5] = 2026-xx-xx
+### Added
+### Changed
+- With `ensemble_corr=True`, masks that only apply to multiple time stamps are ignored with a warning to the user
+  instead of raising and exiting. This allows for re-use of recipes with and without ensemble correlation.
+
+### Deprecated
+### Removed
+### Fixed
+
+
 ## [0.9.4] = 2026-02-27
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## [0.9.5] = 2026-xx-xx
+## [0.9.5] = 2026-05-21
 ### Added
+- PIV interrogation windows can now be pre-masked if they contain too little signal. This can be controlled by
+  the parameter `signal_threshold` in `Frames.get_piv`. Default is 0.2 meaning that if any of the 2 interrogation
+  window in a window pair has only 20% intensities above zero, the window is discarded. This should only be used
+  when frames have been differenced or normalized.
 ### Changed
 - With `ensemble_corr=True`, masks that only apply to multiple time stamps are ignored with a warning to the user
   instead of raising and exiting. This allows for re-use of recipes with and without ensemble correlation.

--- a/docs/user-guide/plot/index.rst
+++ b/docs/user-guide/plot/index.rst
@@ -87,7 +87,8 @@ maximum value you wish to show on a color scale. Furthermore, you may add an opt
 a colorbar in the lower left corner. This colorbar will be bounded by the values supplied with ``vmin`` and ``vmax``.
 If you do not supply ``vmin`` and ``vmax``, then a standard colorbar with limits of 0 and 3 with pretty breaks is used.
 Note that any parameter added is not mandatory! If you leave the parameters out, then default values will be used
-instead.
+instead. ``colorbar_loc`` controls the location of the colorbar, ``0`` is lower left, ``1`` lower right,
+``2`` upper right, ``3`` upper left (default: ``0``).
 
 * quiver (default): "quivers" are arrows pointing into the vector direction, with the length and (possibly) color
   representing the scalar value of the velocity. See |quiver|. Especially the ``scale`` parameter is a little counter-

--- a/docs/user-guide/velocimetry/index.rst
+++ b/docs/user-guide/velocimetry/index.rst
@@ -77,12 +77,21 @@ in :ref:`frames_ug`.
                     engine: numba
 
         Here the ``engine: numba`` ensures that the much faster numba implementation is used (default).
-        ``window_size: 64`` overrides any window size provided in the camera configuration and sets it to 64. When
-        using the engine parameter with ``numba`` or ``numpy``, you can also provide memory safety margins by manually
+        ``window_size: 64`` overrides any window size provided in the camera configuration and sets it to 64.
+        You can also provide memory safety margins by manually
         adjusting the chunk size with the ``chunksize`` parameter. If you notice a memory warning is given, and
         ``chunksize`` is set to 5, try manually setting it to e.g. 3 or 2. The default should be reasonably safe, so we
         hope you never have to touch this parameter at all :-) unless you process very very large videos with very
         large objectives.
+
+        If you have normalized your images, or used differencing in time with thresholding to zero to enhance the
+        visibility of tracers, your image likely contains many zero values leading to interrogation windows with
+        very little signal.This can lead to very noisy results, and also unnecessary computations in areas where only
+        background was visible. To prevent this, you can set a ``signal_threshold`` (default is unset) to filter out
+        windows with little signal. This is computed as the fraction of non-zero pixels in the window stack. This can
+        lead to much better and cleaner results and also speed up the processing by skipping windows with little signal.
+        E.g. 0.2 means that at least 20% of the pixels in the window stack should be non-zero to be included in the
+        correlation processing. This is usually a good default when you use differenced images.
 
         You can also set ``ensemble_corr`` to ``true``.  With this option, cross correlation will be computed for all
         frames, and correlation are averaged per interrogation window, before extracting displacements and estimating
@@ -93,12 +102,14 @@ in :ref:`frames_ug`.
         correlation value after filtering on ``s2n_min`` and ``corr_min``. Any windows that yield lower amounts are
         set to missing and will not yield any velocity. Default for this value is 0.2.
 
+
         .. note::
 
             It seems a little superfluous to have a section called ``velocimetry``, then a subsection ``get_piv`` and then
             the flags used in ``get_piv``, however, we wish to keep the option open to add other velocimetry methods here.
             Perhaps in the near future we may offer a method ``get_ptv`` to use Particle Tracking Velocimetry
-            instead of Partical Image Velocimetry. This method follows particles instead of using cross correlation.
+            instead of Particle Image Velocimetry. Or `get_stiv` to retrieve velocities over lines using
+            Space-Time Image Velocimetry (STIV).
 
     .. tab-item:: API
 
@@ -124,7 +135,9 @@ in :ref:`frames_ug`.
         You may also set ``memory_factor`` to a higher amount than the default (2). ``memory_factor``
         decides on the fraction of the memory reserved for one entire chunk of computation. E.g. by setting it to 4 only
         1/4th of the available memory is assumed to be available. In practice, for large problems, more temporary
-        memory storage is needed within the subprocessing. Passing ``ensemble_corr=True`` uses ensemble correlation
+        memory storage is needed within the subprocessing. Use ``signal_threshold`` to remove windows with little signal
+        after preprocessing. E.g. 0.2 will remove windows with less than 20% non-zero pixels. Passing
+        ``ensemble_corr=True`` uses ensemble correlation
         averaging. This provides additional control for tuning of the signal-to-noise ratio with ``corr_min``
         (default: 0.3) which is the minimum correlation value accepted, and ``s2n_min`` (default=3) which controls
         the minimum signal-to-noise ratio accepted. Finally a ``count_min`` (default=0.2) can be provided, which

--- a/pyorc/__init__.py
+++ b/pyorc/__init__.py
@@ -1,6 +1,6 @@
 """pyorc: free and open-source image-based surface velocity and discharge."""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 from .api import CameraConfig, CrossSection, Frames, Transect, Velocimetry, Video, get_camera_config, load_camera_config  # noqa
 from .project import *  # noqa

--- a/pyorc/api/mask.py
+++ b/pyorc/api/mask.py
@@ -5,6 +5,7 @@ import functools
 import warnings
 
 import numpy as np
+import xarray as xr
 
 from pyorc import helpers
 from pyorc.const import corr, s2n, v_x, v_y
@@ -25,7 +26,7 @@ def _base_mask(time_allowed=False, time_required=False, multi_timestep_required=
     ----------
     time_allowed : bool, optional
         If set, the dimension "time" is allowed, if not set, mask method can only be applied on datasets without "time"
-    time_required
+    time_required : bool, optional
         If set, the dimension "time" is required, if not set, mask method does not require dimension "time" in dataset.
     multi_timestep_required : bool, optional
         If set, the masking method requires multiple timesteps in the dataset in order to be applicable.
@@ -48,6 +49,7 @@ def _base_mask(time_allowed=False, time_required=False, multi_timestep_required=
                 ds = ref._obj.mean(dim="time", keep_attrs=True)
             else:
                 ds = ref._obj
+            # check if multiple time steps are required, then also time is required
             if not ds.velocimetry.is_velocimetry:
                 raise AssertionError("Dataset is not a valid velocimetry dataset")
             if time_required:
@@ -57,23 +59,22 @@ def _base_mask(time_allowed=False, time_required=False, multi_timestep_required=
                         'This mask requires dimension "time". The dataset does not contain dimension "time" or you '
                         "have set `reduce_time=True`. Apply this mask without applying any reducers in time."
                     )
-            if time_required:
-                if "time" not in ds:
-                    raise AssertionError(
-                        "This mask requires dimension `time`. The dataset does not contain dimension `time`."
-                        "Apply this mask before applying any reducers in time."
-                    )
                 # only check for this, when time is required
                 if multi_timestep_required:
+                    print("SHOULD REACH THIS POINT")
                     if len(ds.time) < 2:
-                        raise AssertionError(
-                            "This mask requires multiple timesteps in the dataset in order to be applicable. This "
-                            "error typically occurs when applying `Frames.get_piv(ensemble_corr=True)` as this only "
-                            "yields one single time step."
+                        warnings.warn(
+                            "This mask requires multiple timesteps in the dataset in order have an effect. This "
+                            "warning typically occurs when applying `Frames.get_piv(ensemble_corr=True)` as this only "
+                            "yields one single time step.",
+                            stacklevel=2,
                         )
             if not (time_allowed or time_required) and "time" in ds:
                 # function must be applied per time step
                 mask = ds.groupby("time", squeeze=False).map(mask_func, **kwargs)
+            elif multi_timestep_required and len(ds.time) < 2:
+                # just pass Trues everywhere
+                mask = xr.DataArray(True, dims=("y", "x"), coords={"y": ds.y, "x": ds.x})
             else:
                 # apply the wrapped mask function as is
                 mask = mask_func(ds, **kwargs)
@@ -211,6 +212,18 @@ class _Velocimetry_MaskMethods:
 
         """
         return self[corr] > tolerance
+
+    @_base_mask(time_allowed=True)
+    def s2n(self, tolerance=10):
+        """Mask values with too low signal to noise (s2n).
+
+        Parameters
+        ----------
+        tolerance : float (>0)
+            tolerance for s2n value (default: 10). If s2n is lower than tolerance, it is masked
+
+        """
+        return self[s2n] > tolerance
 
     @_base_mask(time_required=True, multi_timestep_required=True)
     def outliers(self, tolerance=1.0, mode="or"):

--- a/pyorc/api/mask.py
+++ b/pyorc/api/mask.py
@@ -61,7 +61,6 @@ def _base_mask(time_allowed=False, time_required=False, multi_timestep_required=
                     )
                 # only check for this, when time is required
                 if multi_timestep_required:
-                    print("SHOULD REACH THIS POINT")
                     if len(ds.time) < 2:
                         warnings.warn(
                             "This mask requires multiple timesteps in the dataset in order have an effect. This "

--- a/pyorc/api/plot.py
+++ b/pyorc/api/plot.py
@@ -54,6 +54,7 @@ def _base_plot(plot_func):
         mode="local",
         ax=None,
         add_colorbar=False,
+        colorbar_loc=0,
         add_cross_section=True,
         add_text=False,
         text_prefix="",
@@ -75,6 +76,8 @@ def _base_plot(plot_func):
             If None (default), use the current axes. Not applicable when using facets.
         add_colorbar : boolean, optional
             if True, a colorbar is added to axes (default: False)
+        colorbar_loc : int, optional
+            location of colorbar, 0 is lower left, 1 lower right, 2 upper right, 3 upper left (default: 0)
         add_cross_section : boolean, optional
             if True, and a transect is plotted, the transect coordinates are plotted (default: True)
         add_text : boolean, optional
@@ -169,7 +172,7 @@ def _base_plot(plot_func):
         else:
             primitive = plot_func("", x, y, s, ax, **kwargs)
         if add_colorbar:
-            cbar(ax, primitive)
+            cbar(ax, primitive, loc=colorbar_loc)
         if mode == "local":
             ax.set_aspect("equal")
         if is_transect:
@@ -692,7 +695,7 @@ def pcolormesh(_, x, y, s=None, ax=None, **kwargs):
     return primitive
 
 
-def cbar(ax, p, size=12, **kwargs):
+def cbar(ax, p, size=12, loc=0, **kwargs):
     """Add colorbar to existing axes.
 
     In case camera mode is used, the colorbar will get a bespoke layout and will be placed inside the axes object.
@@ -705,6 +708,8 @@ def cbar(ax, p, size=12, **kwargs):
         used to define colorbar
     size : float, optional
         fontsize, used for colorbar title
+    loc : int, optional
+        location of colorbar, 0 is lower left, 1 lower right, 2 upper right, 3 upper left (default: 0)
     **kwargs :
         dict, additional settings passed to plt.colorbar
 
@@ -719,7 +724,14 @@ def cbar(ax, p, size=12, **kwargs):
         patheffects.Stroke(linewidth=2, foreground="w"),
         patheffects.Normal(),
     ]
-    cax = ax.inset_axes([0.05, 0.05, 0.02, 0.25])
+    if loc == 1:
+        cax = ax.inset_axes([0.9, 0.05, 0.02, 0.25])
+    elif loc == 2:
+        cax = ax.inset_axes([0.9, 0.7, 0.02, 0.25])
+    elif loc == 3:
+        cax = ax.inset_axes([0.05, 0.7, 0.02, 0.25])
+    else:
+        cax = ax.inset_axes([0.05, 0.05, 0.02, 0.25])
     cb = ax.figure.colorbar(p, cax=cax, **kwargs)
     ticks_loc = cb.get_ticks().tolist()
     cb.set_ticks(mticker.FixedLocator(ticks_loc))

--- a/pyorc/api/velocimetry.py
+++ b/pyorc/api/velocimetry.py
@@ -220,8 +220,7 @@ class Velocimetry(ORCBase):
             "long_name": "Angle of river flow in radians from North",
             "units": "rad",
         }
-        # convert to a Transect object
-        ds_points = xr.Dataset(ds_points, attrs=ds_points.attrs)
+        # add quantiles and rolling if set
         if rolling is not None:
             ds_points = ds_points.rolling(time=rolling, min_periods=1).mean()
         with warnings.catch_warnings():

--- a/pyorc/api/video.py
+++ b/pyorc/api/video.py
@@ -143,7 +143,23 @@ Camera configuration: {:s}
             # set a gridded mask based on the roi points
             self.set_mask_from_exterior(self.stabilize)
         # set end and start frame
-        self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) - 1
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) - 1
+        if frame_count <= 0:
+            if lazy:
+                raise IOError(
+                    f"Video file {fn} has no proper metadata compromising reading frames with `lazy=True`."
+                    f"This usually happens with videos that are unexpectedly and ungracefully closed during writing. "
+                    f"I cannot continue with `lazy=True`. You may re-attempt reading this video with `lazy=False`."
+                )
+            warnings.warn(
+                f"Video file {fn} has no proper metadata compromising reading frames. This usually happens with videos "
+                f"that are unexpectedly and ungracefully closed during writing. I will attempt to read the video... ",
+                stacklevel=2,
+            )
+            frame_count = 3600 * 60  # set to a very high number
+        # if frame_count is negative, likely the video is not gracefully closed while writing,
+        # then frame_count = end_frame
+        self.frame_count = frame_count if frame_count > 0 else end_frame
         if start_frame is not None:
             if start_frame > self.frame_count > 0:
                 raise ValueError("Start frame is larger than total amount of frames")

--- a/pyorc/cv.py
+++ b/pyorc/cv.py
@@ -50,7 +50,7 @@ def _check_valid_frames(cap, frame_number):
     n = -1
     while ret is False:
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_number[n])
-        ret, img = cap.read()
+        ret, _ = cap.read()
         if not (ret):
             last_valid_idx = n
         n -= 1
@@ -957,7 +957,7 @@ def get_time_frames(cap, start_frame, end_frame, lazy=True, fps=None, progress=T
     while ret:
         if n > end_frame:
             break
-        if not lazy:
+        if not lazy and frames is not None:
             frames.append(img)
         t1 = cap.get(cv2.CAP_PROP_POS_MSEC)
         time.append(n * 1000.0 / fps) if fps is not None else time.append(t1)
@@ -972,13 +972,14 @@ def get_time_frames(cap, start_frame, end_frame, lazy=True, fps=None, progress=T
             # invalid time difference, stop reading.
             break
     # do a final check if the last frame(s) are readable by direct seek and read. Sometimes this results in not being
-    # able to r
-    last_valid_idx = _check_valid_frames(cap, frame_number)
-    if last_valid_idx is not None:
-        time = time[:last_valid_idx]
-        frame_number = frame_number[:last_valid_idx]
-        if not lazy:
-            frames = frames[:last_valid_idx]
+    # able to read frames at the end, e.g. caused by a corrupt video
+    if lazy:
+        last_valid_idx = _check_valid_frames(cap, frame_number)
+        if last_valid_idx is not None:
+            time = time[:last_valid_idx]
+            frame_number = frame_number[:last_valid_idx]
+            # if not lazy and frames is not None:
+            #     frames = frames[:last_valid_idx]
     return time, frame_number, frames
 
 

--- a/pyorc/service/camera_config.py
+++ b/pyorc/service/camera_config.py
@@ -41,8 +41,8 @@ def camera_config(
     # open video for dimensions
     video = Video(video_file, start_frame=frame_sample, end_frame=frame_sample + 1, rotation=rotation)
     # extract first frame
-    img = video.get_frame(frame_sample)
-    img_rgb = video.get_frame(frame_sample, method="rgb")
+    img = video.get_frame(0)
+    img_rgb = video.get_frame(0, method="rgb")
     kwargs["height"], kwargs["width"] = img.shape
     # prepare camera config
     cam_config = CameraConfig(rotation=rotation, **kwargs)

--- a/pyorc/service/velocimetry.py
+++ b/pyorc/service/velocimetry.py
@@ -412,6 +412,15 @@ class VelocityFlowProcessor(object):
         self.frames(**self.recipe["frames"])
         self.velocimetry(**self.recipe["velocimetry"])
         if "mask" in self.recipe:
+            # check if ensemble_corr is used, if so, several masks with multi time steps will not do anything, warn.
+            if "velocimetry" in self.recipe and self.recipe["velocimetry"].get("get_piv", {}).get(
+                "ensemble_corr", False
+            ):
+                self.logger.warning(
+                    "You are applying masks on an ensemble correlation velocimetry. This means that the velocimetry "
+                    "only contains one single time step. Any mask requiring multiple time steps will "
+                    "not have any effect."
+                )
             self.mask(**self.recipe["mask"])
         else:
             # no masking so use non-masked velocimetry as masked

--- a/pyorc/velocimetry/ffpiv.py
+++ b/pyorc/velocimetry/ffpiv.py
@@ -38,6 +38,7 @@ def get_ffpiv(
     corr_min: float = 0.2,
     s2n_min: float = 3,
     count_min: float = 0.2,
+    signal_threshold: Optional[float] = None,
 ):
     """Compute time-resolved Particle Image Velocimetry (PIV) using Fast Fourier Transform (FFT) within FF-PIV.
 
@@ -89,6 +90,11 @@ def get_ffpiv(
     count_min : float, optional
         Minimum amount of frame pairs that result in accepted correlation values after filtering on `corr_min` and
         `s2n_min`. Default 0.2. If less frame pairs are available, the velocity is filtered out.
+    signal_threshold : float, optional
+        The threshold for the signal score, which is the fraction of non-zero pixels in the window stack. Windows
+        with a signal score below this threshold will be set to NaN in the correlation array to prevent noisy velocity
+        estimates. Default is None. With noisy data, you may want to increase to filter out windows with little signal.
+        An additional advantage of this is that it can speed up the processing by skipping windows with little signal.
 
     Returns
     -------
@@ -152,10 +158,23 @@ def get_ffpiv(
             corr_min,
             s2n_min,
             count_min,
+            signal_threshold,
         )
     else:
         ds = _get_ffpiv_timestep(
-            frames_chunks, y, x, dt, res_y, res_x, n_cols, n_rows, window_size, overlap, search_area_size, engine
+            frames_chunks,
+            y,
+            x,
+            dt,
+            res_y,
+            res_x,
+            n_cols,
+            n_rows,
+            window_size,
+            overlap,
+            search_area_size,
+            engine,
+            signal_threshold,
         )
     return ds
 
@@ -176,6 +195,7 @@ def _get_ffpiv_mean(
     corr_min,
     s2n_min,
     count_min,
+    signal_threshold,
 ):
     def process_frame_chunk(frame_chunk, corr_min, s2n_min):
         """Process a single frame chunk to compute correlation and signal-to-noise.
@@ -206,6 +226,7 @@ def _get_ffpiv_mean(
             search_area_size=search_area_size,
             normalize=False,
             engine=engine,
+            signal_threshold=signal_threshold,
             verbose=False,
         )
         # Suppress RuntimeWarnings and calculate required metrics
@@ -355,7 +376,20 @@ def _get_ffpiv_mean(
 
 
 def _get_ffpiv_timestep(
-    frames_chunks, y, x, dt, res_y, res_x, n_cols, n_rows, window_size, overlap, search_area_size, engine, **kwargs
+    frames_chunks,
+    y,
+    x,
+    dt,
+    res_y,
+    res_x,
+    n_cols,
+    n_rows,
+    window_size,
+    overlap,
+    search_area_size,
+    engine,
+    signal_threshold,
+    **kwargs,
 ):
     # make progress bar
     pbar = tqdm(range(len(frames_chunks)), position=0, leave=True)
@@ -370,7 +404,15 @@ def _get_ffpiv_timestep(
         # we need at least one image-pair to do PIV
         if len(da) >= 2:
             u, v, corr_max, s2n = _get_uv_timestep(
-                frames_chunks[n], n_cols, n_rows, window_size, overlap, search_area_size, engine=engine, **kwargs
+                frames_chunks[n],
+                n_cols,
+                n_rows,
+                window_size,
+                overlap,
+                search_area_size,
+                engine=engine,
+                signal_threshold=signal_threshold,
+                **kwargs,
             )
             u = (u * res_x / np.expand_dims(dt_chunk, (1, 2))).astype(np.float32)
             v = (v * res_y / np.expand_dims(dt_chunk, (1, 2))).astype(np.float32)
@@ -400,7 +442,9 @@ def _get_ffpiv_timestep(
     return ds
 
 
-def _get_uv_timestep(da, n_cols, n_rows, window_size, overlap, search_area_size, engine="numba"):
+def _get_uv_timestep(
+    da, n_cols, n_rows, window_size, overlap, search_area_size, engine="numba", signal_threshold=None, **kwargs
+):
     # perform cross correlation analysis yielding correlations for each interrogation window
     x_, y_, corr = cross_corr(
         da.values,
@@ -409,6 +453,7 @@ def _get_uv_timestep(da, n_cols, n_rows, window_size, overlap, search_area_size,
         search_area_size=search_area_size,
         normalize=False,
         engine=engine,
+        signal_threshold=signal_threshold,
         verbose=False,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "cython; platform_machine == 'armv7l'",
     "dask",
     "descartes",
-    "ffpiv>=0.2.0",
+    "ffpiv>=0.2.1",
     "flox",
     "geojson",
     "geopandas",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -15,7 +15,7 @@ from shapely import wkt
 import pyorc
 
 # suppress output of plots
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 EXAMPLE_DATA_DIR = os.path.join(os.path.split(__file__)[0], "..", "examples")
 
@@ -390,6 +390,12 @@ def ani_mp4():
 def piv(frames_proj):
     # provide a short piv object
     return frames_proj.frames.get_piv()
+
+
+@pytest.fixture()
+def piv_ens_corr(frames_proj):
+    # provide a short piv object
+    return frames_proj.frames.get_piv(ensemble_corr=True)
 
 
 @pytest.fixture()

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -26,7 +26,8 @@ def test_mask_count(piv):
 
 
 def test_mask_count_ens_corr(piv_ens_corr):
-    piv_ens_corr.velocimetry.mask.count(inplace=True, tolerance=0.3)
+    with pytest.warns(UserWarning, match="requires multiple timesteps"):
+        piv_ens_corr.velocimetry.mask.count(inplace=True, tolerance=0.3)
 
 
 def test_mask_rolling(piv):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -25,6 +25,10 @@ def test_mask_count(piv):
     piv.velocimetry.mask.count(inplace=True)
 
 
+def test_mask_count_ens_corr(piv_ens_corr):
+    piv_ens_corr.velocimetry.mask.count(inplace=True, tolerance=0.3)
+
+
 def test_mask_rolling(piv):
     # check if the method runs
     piv.velocimetry.mask.rolling(inplace=True, tolerance=0.4)
@@ -74,5 +78,6 @@ def test_error_no_time(piv):
 def test_error_single_time_step(piv):
     piv_sel = piv.isel(time=slice(0, 1))
     # now test if an error is raised when no time is present
-    with pytest.raises(AssertionError, match="This mask requires multiple timesteps"):
-        piv_sel.velocimetry.mask.variance()
+    with pytest.warns(UserWarning, match="This mask requires multiple timesteps"):
+        mask = piv_sel.velocimetry.mask.variance()
+    assert bool(mask.all())


### PR DESCRIPTION
fixed #285 and #286. This allows to more flexibly interchange recipes meant for correlation averaging or not, and for pre-filtering of areas with too little signal.