### PR TITLE
297 extend bbox x or y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
+## [0.9.7] = xxxx-xx-xx
+### Added
+### Changed
+- `CameraConfig.rotate_translate_bbox` can now also handle parameter `x_add` and `y_add` to increase the up/downstream
+  and left-right bank distance of the bounding box.
+
+### Deprecated
+### Removed
+### Fixed
+- `CrossSection.get_bbox` returned bounding box coordinates that were not following a predictable order. Function has been
+  recreated to ensure the first corner is upstream-left.
+
+
 ## [0.9.6] = 2026-06-06
 ### Added
-- `CrossSection.create_bbox` create a `CameraConfig` compatible bounding box over a user-selected length upstream
+- `CrossSection.get_bbox` creates a `CameraConfig` compatible bounding box over a user-selected length upstream
   and downstream, which fits nicely around the chosen cross section.
 - `Frames.to_geotiff` writes a GeoTIFF for the selected frame. In the command-line interface `camera-config` allows
   for writing the sample frame to an RGB GeoTIFF using this method.

--- a/pyorc/__init__.py
+++ b/pyorc/__init__.py
@@ -1,6 +1,6 @@
 """pyorc: free and open-source image-based surface velocity and discharge."""
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 
 from .api import CameraConfig, CrossSection, Frames, Transect, Velocimetry, Video, get_camera_config, load_camera_config  # noqa
 from .project import *  # noqa

--- a/pyorc/api/cameraconfig.py
+++ b/pyorc/api/cameraconfig.py
@@ -953,7 +953,9 @@ class CameraConfig:
         new_config.gcps["src"] = src_new
         return new_config, error
 
-    def rotate_translate_bbox(self, angle: float = None, xoff: float = None, yoff: float = None):
+    def rotate_translate_bbox(
+        self, angle: float = None, xoff: float = None, yoff: float = None, x_add: float = None, y_add: float = None
+    ) -> "CameraConfig":
         """Rotate and translate the bounding box.
 
         Parameters
@@ -964,6 +966,10 @@ class CameraConfig:
             Translation distance in x direction in m.
         yoff : float, optional
             Translation distance in y direction in m.
+        x_add : float, optional
+            Additional length to grow the bounding box in the up-to-downstream direction in m.
+        y_add : float, optional
+            Additional length to grow the bounding box in the cross-stream direction in m.
 
         Returns
         -------
@@ -1013,6 +1019,37 @@ class CameraConfig:
 
         # Apply translation
         bbox = shapely.affinity.translate(bbox, xoff=dx, yoff=dy)
+
+        # Grow bbox with x_add in x direction
+        if x_add is not None:
+            # get new coordinates from bbox after rotation and translation
+            coords = list(bbox.exterior.coords)
+            # make linestrings of up-to-downstream edges
+            l1 = LineString(coords[0:2])
+            l2 = LineString(coords[2:4])
+            # scale
+            fact = (l1.length + x_add) / l1.length
+            print(fact)
+            l1_scaled = shapely.affinity.scale(l1, xfact=fact, yfact=fact, origin="center")
+            l2_scaled = shapely.affinity.scale(l2, xfact=fact, yfact=fact, origin="center")
+            new_coords = list(l1_scaled.coords) + list(l2_scaled.coords)
+            bbox = Polygon(new_coords)
+        # Grow bbox with y_add in y-direction
+        if y_add is not None:
+            # get new coordinates from bbox after rotation and translation
+            coords = list(bbox.exterior.coords)
+            # make linestrings of cross-stream edges
+            l1 = LineString([coords[0], coords[3]])
+            l2 = LineString([coords[1], coords[2]])
+            # scale
+            fact = (l1.length + y_add) / l1.length
+            print(fact)
+            l1_scaled = shapely.affinity.scale(l1, xfact=fact, yfact=fact, origin="center")
+            l2_scaled = shapely.affinity.scale(l2, xfact=fact, yfact=fact, origin="center")
+            new_coords = list(l1_scaled.coords) + list(l2_scaled.coords)
+            # bring back original order of coordinates, this is needed to ensure that the bbox is in the right direction
+            new_coords = [new_coords[0], new_coords[2], new_coords[3], new_coords[1]]
+            bbox = Polygon(new_coords)
         new_config.bbox = bbox
         return new_config
 

--- a/pyorc/api/cross_section.py
+++ b/pyorc/api/cross_section.py
@@ -122,6 +122,37 @@ def _histogram_union(edges, hist1, hist2):
     return 2 - union
 
 
+def _find_infinite_intersection(line1, line2):
+    """Find the intersection point of two lines, even if they do not intersect within the line segments."""
+    # Extract coordinates
+    x1, y1 = line1.coords[0]
+    x2, y2 = line1.coords[1]
+    x3, y3 = line2.coords[0]
+    x4, y4 = line2.coords[1]
+
+    # Line 1 as: a1*x + b1*y = c1
+    a1 = y2 - y1
+    b1 = x1 - x2
+    c1 = a1 * x1 + b1 * y1
+
+    # Line 2 as: a2*x + b2*y = c2
+    a2 = y4 - y3
+    b2 = x3 - x4
+    c2 = a2 * x3 + b2 * y3
+
+    # Determinant
+    determinant = a1 * b2 - a2 * b1
+
+    if determinant == 0:
+        return None  # Lines are parallel and will never intersect
+
+    # Solve for intersection point
+    x = (b2 * c1 - b1 * c2) / determinant
+    y = (a1 * c2 - a2 * c1) / determinant
+
+    return geometry.Point(x, y)
+
+
 class CrossSection:
     """Water Level functionality."""
 
@@ -565,6 +596,9 @@ class CrossSection:
     def get_bbox(self, h: float, length: float = 2.0, offset: float = 0.0) -> geometry.Polygon:
         """Create a closed single bounding box for the cross section for use in the CameraConfig.
 
+        The bounding box coordinate order is from upstream-left, to downstream-left, to downstream-right, to
+        upstream-right, and back to upstream-left. This is computed with geometrical operations.
+
         Parameters
         ----------
         h : float
@@ -593,12 +627,33 @@ class CrossSection:
         csl_2d = [transform(lambda *args: args[:2], line) for line in csl]  # make 2D for bounding box creation
         line1 = csl_2d[0]
         line2 = csl_2d[-1]
-        # combine
-        lines = geometry.MultiLineString([line1, line2])
 
-        # return minimum rotated bbox
-        return lines.minimum_rotated_rectangle
-        
+        diff_coord = (np.array(line1.centroid.coords[0]) - np.array(line2.centroid.coords[0])) / 2
+
+        # move l2 to centroid
+        line_middle = affinity.translate(line2, xoff=diff_coord[0], yoff=diff_coord[1])
+        # make line the right required length
+        fact = length / line_middle.length
+        line_middle = affinity.scale(line_middle, xfact=fact, yfact=fact)
+        # make a line that crosses the left and right line so that we can find the crossings with the left and right
+        # bank. This line is the geometric center between the left and right line.
+        line_cross = affinity.rotate(line_middle, 90, origin=line_middle.centroid)
+        # find the crossings in order line1 - line2 so that we can keep the coordinate order of the bbox in control
+        p_cross1 = _find_infinite_intersection(line1, line_cross)
+        p_cross2 = _find_infinite_intersection(line2, line_cross)
+        p_length = geometry.Point(*line_middle.coords[0])
+        dst_corners = [
+            np.array(p_cross1.xy).flatten().tolist(),
+            np.array(p_cross2.xy).flatten().tolist(),
+            np.array(p_length.xy).flatten().tolist(),
+        ]
+        bbox = cv.get_aoi(dst_corners, resolution=None, method="width_length")
+        return bbox
+        # # combine
+        # lines = geometry.MultiLineString([line1, line2])
+
+        # # return minimum rotated bbox
+        # return lines.minimum_rotated_rectangle
 
     def get_bbox_dry_wet(
         self,

--- a/pyorc/api/cross_section.py
+++ b/pyorc/api/cross_section.py
@@ -649,11 +649,6 @@ class CrossSection:
         ]
         bbox = cv.get_aoi(dst_corners, resolution=None, method="width_length")
         return bbox
-        # # combine
-        # lines = geometry.MultiLineString([line1, line2])
-
-        # # return minimum rotated bbox
-        # return lines.minimum_rotated_rectangle
 
     def get_bbox_dry_wet(
         self,

--- a/pyorc/cv.py
+++ b/pyorc/cv.py
@@ -116,7 +116,7 @@ def _get_aoi_corners(dst_corners, resolution=None):
 
 
 def _get_aoi_width_length(dst_corners):
-    points = [Point(x, y) for x, y, _ in dst_corners]
+    points = [Point(x, y) for x, y in np.array(dst_corners)[:, 0:2]]  # make sure Z is skipped
     linecross = LineString([points[0], points[1]])
     # linecross = LineString(dst_corners[0:2])
     length = np.abs(_get_perpendicular_distance(points[-1], linecross))

--- a/tests/test_cameraconfig.py
+++ b/tests/test_cameraconfig.py
@@ -199,6 +199,12 @@ def test_rotate_translate_bbox(cam_config_6gcps):
     assert np.isclose(bbox_rotated.area, cam_config_6gcps.bbox.area)
 
 
+def test_rotate_translate_bbox_add(cam_config_6gcps):
+    bbox_growth = cam_config_6gcps.rotate_translate_bbox(x_add=None, y_add=2).bbox
+    # assert if the surface is larger than the original one
+    assert bbox_growth.area > cam_config_6gcps.bbox.area
+
+
 def test_set_bbox_from_3points(cam_config_6gcps, corners_length_width, bbox_length_width):
     """Test if defining bbox from 3 points works as expected."""
     cam_config_6gcps.set_bbox_from_width_length(corners_length_width)

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -200,9 +200,12 @@ def test_cs_repr(cs):
 
 
 def test_get_bbox(cs):
-    bbox = cs.get_bbox(h=92.09)
+    z = min(cs.z[0], cs.z[-1]) - 0.05
+    h = cs.camera_config.z_to_h(z)
+    bbox = cs.get_bbox(h=h)
     assert isinstance(bbox, geometry.Polygon)
     assert not bbox.has_z
+
 
 def test_get_bbox_dry_wet(cs):
     # check also what happens with a double geom in wet part


### PR DESCRIPTION
fixed #297 and improved #295 by ensuring that the drawn bounding box coordinates have a fixed order starting with upstream-left.