### PR TITLE
Fix OpenCV 5 compatibility in camera calibration reprojection error calculation

### DIFF
--- a/pyorc/cv.py
+++ b/pyorc/cv.py
@@ -654,8 +654,20 @@ def calibrate_camera(
     # remove badly performing images and recalibrate
     errs = []
     for i in range(len(obj_pts)):
-        img_pts2, _ = cv2.projectPoints(obj_pts[i], rvecs[i], tvecs[i], camera_matrix, dist_coeffs)
-        errs.append(cv2.norm(img_pts[i], img_pts2, cv2.NORM_L2) / len(img_pts2))
+        img_pts2, _ = cv2.projectPoints(
+                obj_pts[i],
+                rvecs[i],
+                tvecs[i],
+                camera_matrix,
+                dist_coeffs
+        )
+        
+        img1 = img_pts[i].reshape(-1, 2)
+        img2 = img_pts2.reshape(-1, 2)
+
+        errs.append(
+             cv2.norm(img1, img2, cv2.NORM_L2) / len(img2)
+        )
 
     if tolerance is not None:
         # remove high error

--- a/pyorc/cv.py
+++ b/pyorc/cv.py
@@ -661,7 +661,7 @@ def calibrate_camera(
                 camera_matrix,
                 dist_coeffs
         )
-        
+
         img1 = img_pts[i].reshape(-1, 2)
         img2 = img_pts2.reshape(-1, 2)
 
@@ -678,8 +678,20 @@ def calibrate_camera(
         ret, camera_matrix, dist_coeffs, rvecs, tvecs = cv2.calibrateCamera(obj_pts, img_pts, frame_size, None, None)
         errs = []
         for i in range(len(obj_pts)):
-            img_pts2, _ = cv2.projectPoints(obj_pts[i], rvecs[i], tvecs[i], camera_matrix, dist_coeffs)
-            errs.append(cv2.norm(img_pts[i], img_pts2, cv2.NORM_L2) / len(img_pts2))
+            img_pts2, _ = cv2.projectPoints(
+                obj_pts[i],
+                rvecs[i],
+                tvecs[i],
+                camera_matrix,
+                dist_coeffs
+            )
+            # Normalize point array shapes before computing the reprojection error.
+            # OpenCV 5 requires matching array layouts for cv2.norm().
+            detected_pts = img_pts[i].reshape(-1, 2)
+            reprojected_pts = img_pts2.reshape(-1, 2)
+
+            error = cv2.norm(detected_pts, reprojected_pts, cv2.NORM_L2)
+            errs.append(error / len(reprojected_pts))
     print(f"Average error on point reconstruction is {np.array(errs).mean()}")
     return camera_matrix, dist_coeffs
 


### PR DESCRIPTION
## Summary

This PR proposes a fix for one of the OpenCV 5 compatibility issues discussed in #302.

## Problem

While testing with:

- Python 3.14.4
- OpenCV 5.0.0

`tests/test_cameraconfig.py::test_camera_calib` failed during the reprojection error calculation inside `calibrate_camera()`.

The point arrays returned by `cv2.projectPoints()` and the detected chessboard corner points had different array layouts, causing `cv2.norm()` to fail with an input type mismatch.

## Solution

Normalize both point arrays to shape `(N, 2)` before computing the reprojection error.

The same change is applied in both reprojection error calculation paths.

## Validation

- Reproduced the failure locally with Python 3.14.4 and OpenCV 5.0.0.
- Verified the output shape of `cv2.projectPoints()` using a minimal example.
- Confirmed that `tests/test_cameraconfig.py::test_camera_calib` passes after the change.

Thanks for the guidance on targeting the `302-opencv-5` branch. I'm happy to make any additional changes if needed to maintain backward compatibility.